### PR TITLE
Correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ printf('Your transaction ID is %s', $transaction->getAttribute('id'));
 
 
 // commit() sends the transaction to the network, once sent this can't be undone.
-$arweave->commit($transaction);
+$arweave->api()->commit($transaction);
 ```
 
 #### Getting data from the network


### PR DESCRIPTION
Line 44 seems incorrect. It generates the following error "Fatal error: Uncaught Error: Call to undefined method Arweave\SDK\Arweave::commit() in path to php script
$arweave->commit($transaction);

The example page shows the correct syntax as the following
$arweave->api()->commit($transaction);

This code does work for me when tested



