### PR TITLE
update getLastTransaction to use /tx_anchor

### DIFF
--- a/Arweave/SDK/Support/API.php
+++ b/Arweave/SDK/Support/API.php
@@ -142,7 +142,7 @@ class API
      */
     public function getLastTransaction(string $wallet_address): string
     {
-        return $this->get(sprintf('wallet/%s/last_tx', $wallet_address));
+            return $this->get(sprintf('/tx_anchor'));
     }
 
     /**


### PR DESCRIPTION
There was a limitation that would only allow 1 transaction per block. This was caused by the method getLastTransaction() it had not been updated to use the new tx_anchor endpoint

This change adds support for the tx_anchor endpoint.

I have tested this and it works on my test machine