### PR TITLE
Fix issue #3 / Add endpoint tx_anchor

### DIFF
--- a/Arweave/SDK/Arweave.php
+++ b/Arweave/SDK/Arweave.php
@@ -63,7 +63,7 @@ class Arweave
         }, array_keys($attributes['tags'] ?? []));
 
         $transaction = new Transaction([
-            'last_tx'  => $this->api->getLastTransaction($wallet->getAddress()),
+            'last_tx'  => $this->api->getTransactionAnchor(),
             'owner'    => $wallet->getOwner(),
             'tags'     => $encoded_tags,
             'target'   => $attributes['target'] ?? '',

--- a/Arweave/SDK/Support/API.php
+++ b/Arweave/SDK/Support/API.php
@@ -146,6 +146,18 @@ class API
     }
 
     /**
+     * Get the tx_anchor
+     *
+     * @param
+     *
+     * @return string|null
+     */
+    public function getTransactionAnchor()
+    {
+        return $this->get(sprintf('/tx_anchor'));
+    }
+
+    /**
      * Get the last transaction ID for the given wallet address.
      *
      * @param  string $wallet_address


### PR DESCRIPTION
This adds support for the endpoint tx_anchor

This change enables multiple transactions per block the current version of the SDK is limited to 1 transaction per wallet per block