### PR TITLE
Upgrade to support PHP 8

### DIFF
--- a/Arweave/SDK/Support/API.php
+++ b/Arweave/SDK/Support/API.php
@@ -89,7 +89,13 @@ class API
      */
     public function getTransaction(string $transaction_id)
     {
-        return new Transaction($this->get(sprintf('tx/%s', $transaction_id)));
+        $response = $this->get(sprintf('tx/%s', $transaction_id));
+
+        if (! is_array($response)) {
+            throw new Exception($response);
+        }
+
+        return new Transaction($response);
     }
 
     /**

--- a/Arweave/SDK/Support/Transaction.php
+++ b/Arweave/SDK/Support/Transaction.php
@@ -124,7 +124,7 @@ class Transaction
 
     public function verify(): bool
     {
-        $public_key = RSAKey::createFromJWK(JWK::create([
+        $public_key = RSAKey::createFromJWK(new JWK([
             'kty' => 'RSA',
             'e'   => 'AQAB',
             'n'   => $this->attributes['owner']

--- a/Arweave/SDK/Support/Wallet.php
+++ b/Arweave/SDK/Support/Wallet.php
@@ -71,7 +71,7 @@ class Wallet
 
     private function RSAPrivateFromJWK(array $jwk): RSA
     {
-        $private_key = RSAKey::createFromJWK(JWK::create($jwk));
+        $private_key = RSAKey::createFromJWK(new JWK($jwk));
 
         $rsa = new RSA;
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Or add the following to your project `composer.json` file.
 ## Quick Examples
 
 
-#### Sending data to the network 
+#### Sending data to the network
 
 
 ```php
@@ -41,7 +41,7 @@ printf('Your transaction ID is %s', $transaction->getAttribute('id'));
 
 
 // commit() sends the transaction to the network, once sent this can't be undone.
-$arweave->commit($transaction);
+$arweave->api()->commit($transaction);
 ```
 
 #### Getting data from the network
@@ -149,7 +149,7 @@ To load a wallet you need a Key file. Arweave uses JSON Web Keys (JWK) as the ke
   "dq": "gk_Sb5cFAQQ...",
   "qi": "k65nfXdh4qx..."
 }
-``` 
+```
 
 We first need to decode our JWK file to a PHP array, then we can simply pass that array into a new `Wallet` object.
 

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "ext-curl": "*",
         "ext-mbstring": "*",
         "ext-gmp": "*",
-        "web-token/jwt-framework": "^1.3",
-        "web-token/jwt-core": "^1.3"
+        "web-token/jwt-framework": "^1.3 || ~2.0",
+        "web-token/jwt-core": "^1.3 || ~2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "phpseclib/phpseclib": "^2.0",
-        "php": "^7.0",
+        "php": "~7.0 || ~8.0",
         "ext-curl": "*",
         "ext-mbstring": "*",
         "ext-gmp": "*",


### PR DESCRIPTION
This pull request:
- Upgrades the package to support PHP 8
- Upgrades the package to allow for use of web-tokens 2.0
- Fixes a typo in the readme
- Updates the transaction methods to not break when receiving text responses (e.g. `"PENDING"`)

I've successfully tested the package on PHP 8, and all of the methods that get data worked fine. I wasn't able to FULLY verify the `createTransaction` flow worked as expected, but that's just because I'm still new to working with Arweave, and as far as I can tell it's working. 